### PR TITLE
Fix nativefs.createDirectory on windows

### DIFF
--- a/nativefs.lua
+++ b/nativefs.lua
@@ -292,7 +292,7 @@ end
 function nativefs.createDirectory(path)
 	local current = ''
 	for dir in path:gmatch('[^/\\]+') do
-		current = (current == '' and current or current .. '/') .. dir
+		current = current .. dir .. '/'
 		local info = nativefs.getInfo(current, 'directory')
 		if not info and not mkdir(current) then return false, "Could not create directory " .. current end
 	end


### PR DESCRIPTION
Currently, createDirectory fails on windows, because a slash is mandatory at the beginning of the absolute path, i.e. with the drive letter and the colon; `C:` fails even the getInfo process without a slash of any kind (\ or /); only `C:\` or `C:/` gets recognized as a correct path.

The change i made, as far as i can tell, won't stop the function from working on linux/osx either, although testing that would probably be a good idea;
the issue i could see is if/when gmatch would return the first directory instead of an empty string in front of the first slash, and if that would fail because the path would expect an initial slash as the root... if it doesn't, then it should work.

But if it does fail, this might not have a clean solution unless the implementation is separated by OS, with current being `'/'` initially on non-windows, and `''` otherwise, alongside my change.